### PR TITLE
Image overflow fix

### DIFF
--- a/Assets/style.css
+++ b/Assets/style.css
@@ -142,7 +142,7 @@ li {
 /*About me section for Phones - make it a column with header, picture, then article.*/
 @media screen and (max-width: 768px) {
     #about {
-        /* This sets up the grid system for the About Me section on phones. It will include the header (#about-header), introductory article (#intro), and the profile picture (#me). */
+        /* This sets up the grid system for the About Me section on phones (or other devices smaller than 768px). It will include the header (#about-header), introductory article (#intro), and the profile picture (#me). */
         display: grid;
         width: 100%;
         grid-template-columns: 1fr;
@@ -150,13 +150,13 @@ li {
         grid-gap: 0.2rem;
         align-items: center;
     }
-    
+
     #about-header {
         /* This makes the About Me section header start at row 1, column 1 and have it span for 1 row and 1 columns. */
         grid-area: 1 / 1 / span 1 / span 1;
         text-align: center;
     }
-    
+
     #intro {
         /* This makes the About Me section article start at row 3, column 1 and have it span for 1 row and 1 column. */
         grid-area: 3 / 1 / span 1 / span 1;
@@ -164,7 +164,7 @@ li {
         line-height: 2;
         padding: 2rem;
     }
-    
+
     #me {
         /* This makes the About Me section article start at row 2, column 1 and have it span for 1 row and 1 column. */
         grid-area: 2 / 1 / span 1 / span 1;
@@ -178,6 +178,9 @@ li {
 }
 
 /*Projects*/
+#projects > * {
+    border: #01DBFF;
+}
 
 /*This section deals with the visual appearance of all buttons.*/
 button {
@@ -200,18 +203,15 @@ button:focus {
     cursor: pointer;
 }
 
-
-/* Makes cursor have a no-symbol when hovering over - For 
-cursor: not-allowed; */
-
-.soon {
-    width: 300px;
-    height: 300px;
+/*This section deals with the images in the Projects section*/
+.thumbnail {
+    max-width: 100%;
+    height: auto;
 }
 
-.thumbnail {
-    width: 900px;
-    height: 500px;
+.coming-soon {
+    width: 300px;
+    height: 300px;
 }
 
 /*-----------------------------------------------*/
@@ -240,7 +240,6 @@ cursor: not-allowed; */
 #fifth {
     width: 100%;
     text-align: center;
-    /* flex-shrink: 1; */
 }
 
 #first {

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Claire Lee</title>
     <link rel="stylesheet" href="./Assets/style.css">
-    <!--This stylesheet is what allows the github icon to appear.-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
 
 <body>
@@ -16,10 +14,8 @@
         <nav>
             <ul>
                 <li><a href="#about">About</a></li>
-                <!-- <li><a href="#skills">Skills</a></li> -->
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="#contact">Contact Me</a></li>
-                <!-- <li><a class="resume" href="#" target="_blank" rel="noopener noreferrer">Resume</a></li> -->
             </ul>
         </nav>
 
@@ -43,12 +39,6 @@
                 src="https://media-exp1.licdn.com/dms/image/C4E03AQGUWoaKUKHksg/profile-displayphoto-shrink_200_200/0/1616515294451?e=1673481600&v=beta&t=KW4fN-hyTrdpbPgDOakq9tuGsZWjhW2E7XZQDmeUUCY"
                 alt-text="Image of Claire Lee">
         </section>
-
-        <!-- Future Update
-        <section id="skills">
-            <h2>Skills</h2>
-    
-        </section> -->
 
         <section id="projects">
             <h2 id="project-header">Projects</h2>
@@ -97,7 +87,7 @@
             <section id="third">
                 <h3>Coming Soon</h3>
                 <figure>
-                    <img class="soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
+                    <img class="coming-soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
                     <figcaption> Stay tuned for this upcoming project!</figcaption>
                 </figure>
                 <div class="buttons" id="third-buttons">
@@ -113,7 +103,7 @@
             <section id="fourth">
                 <h3>Coming Soon</h3>
                 <figure>
-                    <img class="soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
+                    <img class="coming-soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
                     <figcaption> Stay tuned for this upcoming project!</figcaption>
                 </figure>
                 <div class="buttons" id="fourth-buttons">
@@ -129,7 +119,7 @@
             <section id="fifth">
                 <h3>Coming Soon</h3>
                 <figure>
-                    <img class="soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
+                    <img class="coming-soon" src="./Assets/ComingSoon.svg" alt-text="Construction of House">
                     <figcaption> Stay tuned for this upcoming project!</figcaption>
                 </figure>
                 <div class="buttons" id="fifth-buttons">
@@ -154,7 +144,6 @@
                 <li>
                     <strong class="Links">GitHub: </strong>
                     <a href="https://github.com/leeclaire156" target="_blank" rel="noreferrer">
-                        <!--<i style="font-size:24px; color:blue" class="fa">&#xf09b;</i>-->
                         My GitHub
                     </a>
                 </li>


### PR DESCRIPTION
Changed the width of the project images to 100% so that they no longer overflow outside of their parent elements. Also took out some of the future update comments to a scope that is realistic of the timeline left for this project. In addition, the class "soon" for project images three through five are now called "coming-soon".